### PR TITLE
Properly respect JAVA_HOME env var, removed --java-home arg parser

### DIFF
--- a/main/client/src/MillClientMain.java
+++ b/main/client/src/MillClientMain.java
@@ -7,7 +7,10 @@ import java.net.Socket;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.FileChannel;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.lang.Math;
 
 public class MillClientMain {
 
@@ -21,7 +24,7 @@ public class MillClientMain {
 
         List<String> l = new ArrayList<>();
         List<String> vmOptions = new ArrayList<>();
-        l.add("java");
+        l.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
         final Properties props = System.getProperties();
         for(final String k: props.stringPropertyNames()){
             if (k.startsWith("MILL_") && !"MILL_CLASSPATH".equals(k)) {
@@ -52,6 +55,16 @@ public class MillClientMain {
                 .redirectError(new java.io.File(lockBase + "/logs"))
                 .start();
     }
+
+    private static String sha1HashPath(String path) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        MessageDigest md = MessageDigest.getInstance("SHA1");
+        md.reset();
+        byte[] pathBytes = path.getBytes("UTF-8");
+        md.update(pathBytes);
+        byte[] digest = md.digest();
+        return Base64.getEncoder().encodeToString(digest);
+    }
+
     public static void main(String[] args) throws Exception{
         System.exit(main0(args));
     }
@@ -62,10 +75,22 @@ public class MillClientMain {
             System.setProperty("jna.nosys", "true");
         }
         int index = 0;
-        final int processLimit = 5;
+        String jvmHomeEncoding = sha1HashPath(System.getProperty("java.home"));
+        File outFolder = new File("out");
+        String[] totalProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-"));
+        String[] thisJdkProcesses = outFolder.list((dir,name) -> name.startsWith("mill-worker-" + jvmHomeEncoding));
+
+        int processLimit = 5;
+        if(totalProcesses != null) {
+            if(thisJdkProcesses != null) {
+                processLimit -= Math.min(totalProcesses.length - thisJdkProcesses.length, 5);
+            } else {
+                processLimit -= Math.min(totalProcesses.length, 5);
+            }
+        }
         while (index < processLimit) {
             index += 1;
-            String lockBase = "out/mill-worker-" + index;
+            String lockBase = "out/mill-worker-" + jvmHomeEncoding + "-" + index;
             new java.io.File(lockBase).mkdirs();
 
             try(RandomAccessFile lockFile = new RandomAccessFile(lockBase + "/clientLock", "rw");


### PR DESCRIPTION
Instead of using a `--java-home` argument, we properly respect the `JAVA_HOME` env variable pointing to the correct JVM.

That way, we can switch the JVM used by mill by setting the env variable, which works also under Windows.

Linux example:

```
$ JAVA_HOME=/opt/my-jdk mill version
```